### PR TITLE
fix php7.2+ will throw exception

### DIFF
--- a/igetui/IGt.APNPayload.php
+++ b/igetui/IGt.APNPayload.php
@@ -156,7 +156,7 @@ class DictionaryAlertMsg implements ApnMsg{
     var $launchImage;
     var $subtitle;
     var $subtitleLocKey;
-    var $subtitleLocArgs;
+    var $subtitleLocArgs=array();
 
     public function get_alertMsg() {
 


### PR DESCRIPTION
修复php7.2+的异常,Parameter must be an array or an object that implements Countable