### PR TITLE
Fix for PHP8.3

### DIFF
--- a/protobuf/type/pb_string.php
+++ b/protobuf/type/pb_string.php
@@ -35,7 +35,7 @@ class PBString extends PBScalar
 			$string .= $this->base128->set_value($rec << 3 | $this->wired_type);
 		}
 
-		$string .= $this->base128->set_value(strlen($this->value));
+		$string .= $this->base128->set_value(strlen($this->value ? $this->value : ''));
 		$string .= $this->value;
 
 		return $string;


### PR DESCRIPTION
Fix ErrorException: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in .../vendor/getuilaboratory/getui-pushapi-php-client/protobuf/type/pb_string.php:38